### PR TITLE
Enable header navigation buttons to open matching sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
           <li><a href="#contact">Contact</a></li>
           <li><a href="#experience">Experience</a></li>
           <li><a href="#skills">Skills</a></li>
+          <li><a href="#education">Education</a></li>
         </ul>
       </nav>
 
@@ -505,5 +506,6 @@
     <script src="scripts/intro-cube.js" defer></script>
     <script src="scripts/intro-pages.js" defer></script>
     <script src="scripts/sheets.js" defer></script>
+    <script src="scripts/header-nav.js" defer></script>
   </body>
 </html>

--- a/scripts/header-nav.js
+++ b/scripts/header-nav.js
@@ -1,0 +1,26 @@
+(() => {
+  const intro = document.getElementById('intro');
+  const links = document.querySelectorAll('.nav-links a');
+  const pageMap = {
+    education: 1,
+    skills: 2,
+    projects: 3,
+    experience: 4,
+    contact: 5
+  };
+
+  links.forEach(link => {
+    link.addEventListener('click', e => {
+      const target = link.getAttribute('href').slice(1);
+      if (!target) return;
+      e.preventDefault();
+      if (intro) intro.scrollIntoView({ behavior: 'smooth' });
+      if (typeof window.goToIntroPage === 'function' && pageMap[target] != null) {
+        window.goToIntroPage(pageMap[target]);
+      }
+      if (typeof window.openDetailSheet === 'function') {
+        window.openDetailSheet(`${target}-details`);
+      }
+    });
+  });
+})();

--- a/scripts/intro-pages.js
+++ b/scripts/intro-pages.js
@@ -76,6 +76,8 @@
     setTimeout(() => (syncing = false), PAGE_STEP_MS + 120);
   }
 
+  window.goToIntroPage = goToPage;
+
   // --- Cube -> Pages (external hook from cube) ---
   window.onIntroCubeSnap = function(faceIndex){
     const pageIndex = faceToPage[faceIndex];

--- a/scripts/sheets.js
+++ b/scripts/sheets.js
@@ -16,6 +16,8 @@
     }
   }
 
+  window.openDetailSheet = openSheetById;
+
   // Delegate clicks: open with up arrow, close with down arrow or backdrop click
   document.addEventListener('click', (e) => {
     const openBtn = e.target.closest('.page-up-arrow');


### PR DESCRIPTION
## Summary
- Add Education link to the header nav and include navigation script
- Expose helpers to open sheets and switch pages programmatically
- Implement header navigation script to scroll and open the selected section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a47c0dc83209b320591e3051479