### PR TITLE
Fix scroll arrow smooth scroll target

### DIFF
--- a/scripts/fluid-sim.js
+++ b/scripts/fluid-sim.js
@@ -1770,9 +1770,14 @@ function hashCode (s) {
     return hash;
 };
 
-document.querySelector('.scroll-arrow').addEventListener('click', () => {
-    document.querySelector('.content').scrollIntoView({ 
-        behavior: 'smooth'
+const scrollArrow = document.querySelector('.scroll-arrow');
+const introSection = document.getElementById('intro');
+if (scrollArrow && introSection) {
+    scrollArrow.addEventListener('click', (e) => {
+        e.preventDefault();
+        introSection.scrollIntoView({
+            behavior: 'smooth'
+        });
     });
-});
+}
 


### PR DESCRIPTION
## Summary
- Avoid error when clicking hero scroll arrow by checking element and scrolling to intro section

## Testing
- `node --check scripts/fluid-sim.js`

------
https://chatgpt.com/codex/tasks/task_e_689e18df37588320aafa23c08cce9cfd