### PR TITLE
Animate border from top center

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,10 +68,10 @@
 
     <!-- Border wrapper with full-page section under hero -->
     <div class="border-wrapper">
-      <div class="border-top"></div>
-      <div class="border-right"></div>
-      <!-- <div class="border-bottom"></div> -->
-      <div class="border-left"></div>
+      <svg class="border-anim" viewBox="0 0 100 100" preserveAspectRatio="none">
+        <path class="border-path left" pathLength="1" d="M50 0 H0 V100 H50" />
+        <path class="border-path right" pathLength="1" d="M50 0 H100 V100 H50" />
+      </svg>
 
       <section class="intro-combined" id="intro">
         <div class="intro-split">

--- a/styles.css
+++ b/styles.css
@@ -311,49 +311,28 @@ body {
   box-sizing: border-box;
 }
 
-.border-top,
-.border-right,
-.border-bottom,
-.border-left {
+.border-anim {
   position: absolute;
-  background-color: #fff;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
   z-index: 9999;
 }
 
-/* Top border */
-.border-top {
-  top: 0; left: 0;
-  width: 0%; height: 2px;
-  animation: drawTop 1s forwards ease-out;
+.border-path {
+  fill: none;
+  stroke: #fff;
+  stroke-width: 2;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  animation: drawBorder 4s forwards;
 }
-@keyframes drawTop { 0% { width: 0% } 100% { width: 100% } }
 
-/* Right border */
-.border-right {
-  top: 0; right: 0;
-  width: 2px; height: 0%;
-  animation: drawRight 1s forwards ease-out;
-  animation-delay: 1s;
+@keyframes drawBorder {
+  to { stroke-dashoffset: 0; }
 }
-@keyframes drawRight { 0% { height: 0% } 100% { height: 100% } }
-
-/* Bottom border (optional; only if you add it in HTML) */
-.border-bottom {
-  bottom: 0; left: 0;
-  width: 0%; height: 2px;
-  animation: drawBottom 1s forwards ease-out;
-  animation-delay: 2s;
-}
-@keyframes drawBottom { 0% { width: 0% } 100% { width: 100% } }
-
-/* Left border */
-.border-left {
-  top: 0; left: 0;
-  width: 2px; height: 0%;
-  animation: drawLeft 1s forwards ease-out;
-  animation-delay: 3s;
-}
-@keyframes drawLeft { 0% { height: 0% } 100% { height: 100% } }
 
 /* ===============================
    Scrollbar theming (WebKit/Blink)


### PR DESCRIPTION
## Summary
- Replace static border divs with SVG paths for simultaneous left/right drawing from top center
- Simplify border animation CSS to use stroke-dashoffset animation for full perimeter

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e209c67748320939d184f99c1dbdc