### PR TITLE
Sync cube face colors with section backgrounds

### DIFF
--- a/scripts/intro-cube.js
+++ b/scripts/intro-cube.js
@@ -22,10 +22,18 @@
     key.position.set(2, 3, 4);
     scene.add(key);
 
-    // White cube
+    // Color-coded cube faces (education, skills, projects, experience, contact, home)
+    const FACE_COLORS = [
+      0x2e026d, // front  - Education (purple)
+      0x0a838f, // right  - Skills (teal)
+      0x1a690e, // back   - Projects (green)
+      0x693f0a, // left   - Experience (orange)
+      0x6d0038, // top    - Contact (magenta)
+      0x0a2e6d  // bottom - Home (blue)
+    ];
     const cube = new THREE.Mesh(
       new THREE.BoxGeometry(1.8, 1.8, 1.8),
-      new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4, metalness: 0.0 })
+      FACE_COLORS.map(c => new THREE.MeshStandardMaterial({ color: c, roughness: 0.4, metalness: 0.0 }))
     );
     scene.add(cube);
 

--- a/scripts/intro-pages.js
+++ b/scripts/intro-pages.js
@@ -14,7 +14,7 @@
 
   // --- Cube face mapping ---
   // DOM order: 0: Home, 1: Education, 2: Skills, 3: Projects, 4: Experience, 5: Contact
-  const pageToFace = { 1:0, 2:1, 3:2, 4:3, 5:4 };
+  const pageToFace = { 0:5, 1:0, 2:1, 3:2, 4:3, 5:4 };
   const faceToPage = Object.fromEntries(Object.entries(pageToFace).map(([p,f]) => [f, Number(p)]));
 
   let syncing     = false; // programmatic scroll guard
@@ -56,8 +56,8 @@
       });
     }
 
-    // Update cube (Home index 0 does not affect cube)
-    if (nextIdx !== 0 && typeof window.setIntroCubeFace === 'function') {
+    // Update cube orientation to match active page
+    if (typeof window.setIntroCubeFace === 'function') {
       const face = pageToFace[nextIdx];
       if (typeof face === 'number') window.setIntroCubeFace(face);
     }
@@ -99,8 +99,8 @@
       if (idx !== lastActive) {
         setActive(idx, dirRight);
       }
-      // Optional: keep cube aligned while dragging (except for Home)
-      if (idx !== 0 && typeof window.setIntroCubeFace === 'function') {
+      // Keep cube aligned while dragging
+      if (typeof window.setIntroCubeFace === 'function') {
         const face = pageToFace[idx];
         if (typeof face === 'number') window.setIntroCubeFace(face);
       }

--- a/styles.css
+++ b/styles.css
@@ -245,6 +245,14 @@ body {
   padding: 1rem 1.5rem 1.5rem;
 }
 
+/* Page background colors synced with cube faces */
+.page-home       { background-color: #0a2e6d; }
+.page-education  { background-color: #2e026d; }
+.page-skills     { background-color: #0a838f; }
+.page-projects   { background-color: #1a690e; }
+.page-experience { background-color: #693f0a; }
+.page-contact    { background-color: #6d0038; }
+
 .page-inner {
   text-align: center;
   display: flex;


### PR DESCRIPTION
## Summary
- Add per-face materials to intro cube using dark neon palette
- Apply matching background colors to home, education, skills, projects, experience, and contact pages
- Map pages to cube faces so orientation updates for all sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e28779bb08320905e6b851c22020f