### PR TITLE
feat: add section icons to cube

### DIFF
--- a/scripts/intro-cube.js
+++ b/scripts/intro-cube.js
@@ -24,13 +24,14 @@
 
     // Helper: draw an emoji silhouette in white for use as an emissive map
     function makeEmojiTexture(emoji) {
-      const size = 256;
+      // use a larger canvas and draw the emoji smaller so the result looks sharper
+      const size = 512;
       const cvs = document.createElement('canvas');
       cvs.width = cvs.height = size;
       const ctx = cvs.getContext('2d');
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.font = size * 0.7 + 'px serif';
+      ctx.font = size * 0.4 + 'px serif';
       // Draw emoji normally
       ctx.fillText(emoji, size / 2, size / 2);
       // Recolor to white while keeping transparency

--- a/scripts/intro-cube.js
+++ b/scripts/intro-cube.js
@@ -22,7 +22,7 @@
     key.position.set(2, 3, 4);
     scene.add(key);
 
-    // Helper: draw an emoji onto a canvas and use as texture
+    // Helper: draw an emoji silhouette in white for use as an emissive map
     function makeEmojiTexture(emoji) {
       const size = 256;
       const cvs = document.createElement('canvas');
@@ -31,18 +31,23 @@
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       ctx.font = size * 0.7 + 'px serif';
+      // Draw emoji normally
       ctx.fillText(emoji, size / 2, size / 2);
+      // Recolor to white while keeping transparency
+      ctx.globalCompositeOperation = 'source-in';
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(0, 0, size, size);
       return new THREE.CanvasTexture(cvs);
     }
 
     // Icons for each face of the cube (BoxGeometry order: right, left, top, bottom, front, back)
     const faceIcons = ['🎓', '📁', '💼', '✉️', '🏠', '🛠️'];
     const materials = faceIcons.map(icon => new THREE.MeshStandardMaterial({
-      color: 0xffffff,
+      color: 0x000000,
       roughness: 0.4,
       metalness: 0.0,
-      transparent: true,
-      map: makeEmojiTexture(icon)
+      emissive: 0xffffff,
+      emissiveMap: makeEmojiTexture(icon)
     }));
 
     const cube = new THREE.Mesh(new THREE.BoxGeometry(1.8, 1.8, 1.8), materials);

--- a/scripts/intro-cube.js
+++ b/scripts/intro-cube.js
@@ -42,7 +42,10 @@
     }
 
     // Icons for each face of the cube (BoxGeometry order: right, left, top, bottom, front, back)
-    const faceIcons = ['🎓', '📁', '💼', '✉️', '🏠', '🛠️'];
+    // BoxGeometry material order: right, left, top, bottom, front, back
+    // Pages map to cube faces via intro-pages.js (face indices 1–5)
+    // Education 🎓, Projects 💼, Experience 📁, Contact ✉️, Skills 🛠️, Home 🏠
+    const faceIcons = ['🎓', '💼', '📁', '✉️', '🏠', '🛠️'];
     const materials = faceIcons.map(icon => new THREE.MeshStandardMaterial({
       color: 0x000000,
       roughness: 0.4,

--- a/scripts/intro-cube.js
+++ b/scripts/intro-cube.js
@@ -22,11 +22,30 @@
     key.position.set(2, 3, 4);
     scene.add(key);
 
-    // White cube
-    const cube = new THREE.Mesh(
-      new THREE.BoxGeometry(1.8, 1.8, 1.8),
-      new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4, metalness: 0.0 })
-    );
+    // Helper: draw an emoji onto a canvas and use as texture
+    function makeEmojiTexture(emoji) {
+      const size = 256;
+      const cvs = document.createElement('canvas');
+      cvs.width = cvs.height = size;
+      const ctx = cvs.getContext('2d');
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.font = size * 0.7 + 'px serif';
+      ctx.fillText(emoji, size / 2, size / 2);
+      return new THREE.CanvasTexture(cvs);
+    }
+
+    // Icons for each face of the cube (BoxGeometry order: right, left, top, bottom, front, back)
+    const faceIcons = ['🎓', '📁', '💼', '✉️', '🏠', '🛠️'];
+    const materials = faceIcons.map(icon => new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      roughness: 0.4,
+      metalness: 0.0,
+      transparent: true,
+      map: makeEmojiTexture(icon)
+    }));
+
+    const cube = new THREE.Mesh(new THREE.BoxGeometry(1.8, 1.8, 1.8), materials);
     scene.add(cube);
 
     // --- Overall size + hover grow ---

--- a/scripts/intro-pages.js
+++ b/scripts/intro-pages.js
@@ -16,7 +16,7 @@
   // --- Cube face mapping ---
   // DOM order: 0: Home, 1: Education, 2: Skills, 3: Projects, 4: Experience, 5: Contact
   // Home (index 0) leaves the cube orientation unchanged
-  const pageToFace = { 1:1, 2:2, 3:3, 4:4, 5:5 };
+  const pageToFace = { 1:3, 2:2, 3:1, 4:4, 5:5 };
   const faceToPage = Object.fromEntries(
     Object.entries(pageToFace).map(([p, f]) => [f, Number(p)])
   );

--- a/scripts/intro-pages.js
+++ b/scripts/intro-pages.js
@@ -14,8 +14,10 @@
 
   // --- Cube face mapping ---
   // DOM order: 0: Home, 1: Education, 2: Skills, 3: Projects, 4: Experience, 5: Contact
-  const pageToFace = { 1:0, 2:1, 3:2, 4:3, 5:4 };
-  const faceToPage = Object.fromEntries(Object.entries(pageToFace).map(([p,f]) => [f, Number(p)]));
+  const pageToFace = { 0:0, 1:1, 2:2, 3:3, 4:4, 5:5 };
+  const faceToPage = Object.fromEntries(
+    Object.entries(pageToFace).map(([p, f]) => [f, Number(p)])
+  );
 
   let syncing     = false; // programmatic scroll guard
   let paging      = false; // wheel debounce
@@ -56,10 +58,10 @@
       });
     }
 
-    // Update cube (Home index 0 does not affect cube)
-    if (nextIdx !== 0 && typeof window.setIntroCubeFace === 'function') {
-      const face = pageToFace[nextIdx];
-      if (typeof face === 'number') window.setIntroCubeFace(face);
+    // Update cube to reflect active page
+    const face = pageToFace[nextIdx];
+    if (typeof face === 'number' && typeof window.setIntroCubeFace === 'function') {
+      window.setIntroCubeFace(face);
     }
 
     lastActive = nextIdx;
@@ -99,10 +101,10 @@
       if (idx !== lastActive) {
         setActive(idx, dirRight);
       }
-      // Optional: keep cube aligned while dragging (except for Home)
-      if (idx !== 0 && typeof window.setIntroCubeFace === 'function') {
-        const face = pageToFace[idx];
-        if (typeof face === 'number') window.setIntroCubeFace(face);
+      // Keep cube aligned while dragging
+      const face = pageToFace[idx];
+      if (typeof face === 'number' && typeof window.setIntroCubeFace === 'function') {
+        window.setIntroCubeFace(face);
       }
     });
   });

--- a/scripts/intro-pages.js
+++ b/scripts/intro-pages.js
@@ -1,6 +1,7 @@
 (() => {
   const scroller     = document.getElementById('intro-pages');
   const introBottom  = document.querySelector('.intro-bottom');
+  const cubeCanvas   = document.getElementById('intro-cube');
   if (!scroller || !introBottom) return;
 
   // --- Pages & helpers ---
@@ -14,7 +15,8 @@
 
   // --- Cube face mapping ---
   // DOM order: 0: Home, 1: Education, 2: Skills, 3: Projects, 4: Experience, 5: Contact
-  const pageToFace = { 0:0, 1:1, 2:2, 3:3, 4:4, 5:5 };
+  // Home (index 0) leaves the cube orientation unchanged
+  const pageToFace = { 1:1, 2:2, 3:3, 4:4, 5:5 };
   const faceToPage = Object.fromEntries(
     Object.entries(pageToFace).map(([p, f]) => [f, Number(p)])
   );
@@ -62,6 +64,10 @@
     const face = pageToFace[nextIdx];
     if (typeof face === 'number' && typeof window.setIntroCubeFace === 'function') {
       window.setIntroCubeFace(face);
+    }
+
+    if (cubeCanvas) {
+      cubeCanvas.style.pointerEvents = nextIdx === 0 ? 'none' : '';
     }
 
     lastActive = nextIdx;
@@ -133,5 +139,6 @@
 
   // Init: mark page 0 active so its underline animates on first scroll
   pages.forEach((p,i)=>p.classList.toggle('active', i===0));
+  if (cubeCanvas) cubeCanvas.style.pointerEvents = 'none';
   scroller.classList.add('dir-right'); // default wipe direction
 })();

--- a/styles.css
+++ b/styles.css
@@ -202,10 +202,10 @@ body {
 
 /* Nudge the cube (and its frame) down slightly */
 .intro-top {
-  padding-top: 2.25rem; /* was ~1rem */
+  padding-top: 4rem; /* give more breathing room */
 }
 .cube-wrap {
-  margin-top: 0.5rem; /* tiny extra drop */
+  margin-top: 1rem; /* move cube and border down together */
 }
 
 /* Bottom: 2/3 height, full-width horizontal pager */

--- a/styles.css
+++ b/styles.css
@@ -239,8 +239,8 @@ body {
   scroll-snap-align: start;
   display: flex;
 
-  align-items: flex-start;  /* top */
-  justify-content: center;  /* centered horizontally */
+  align-items: center;       /* vertically center section content */
+  justify-content: center;   /* centered horizontally */
 
   padding: 1rem 1.5rem 1.5rem;
 }
@@ -400,7 +400,7 @@ html { scrollbar-color: #343434 #0b0b0b; scrollbar-width: thin; }
 .page-up-arrow:hover,
 .page-up-arrow:focus-visible {
   animation-play-state: paused;
-  transform: translateY(-10px) scale(1.08);
+  transform: translateY(-10px) scale(1.15); /* subtle grow on hover */
   outline: none;
 }
 


### PR DESCRIPTION
## Summary
- map intro pages to all cube faces including home
- show section icons on each cube side using emoji textures
- keep cube face synced with active page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ad984108320a3bdba25e52e9a0a