### PR TITLE
feat: add interaction-driven dynamic guide

### DIFF
--- a/scripts/dynamic-guide.js
+++ b/scripts/dynamic-guide.js
@@ -20,6 +20,10 @@
       this.timeoutId     = null;
       this.isHovered     = false;
 
+      this.messageQueue  = [];
+      this.interactions  = options.interactions || [];
+      this.timeTriggers  = options.timeTriggers || [];
+
       this.init();
     }
 
@@ -53,16 +57,24 @@
         // this.loopEnabled = true;
         // this.cycleMessages();
       });
+
+      this.setupInteractions();
+      this.setupTimeTriggers();
     }
 
     cycleMessages() {
       if (!this.loopEnabled) return;
 
-      if (this.currentIndex >= this.messages.length) {
-        this.currentIndex = 0;
+      let message;
+      if (this.messageQueue.length > 0) {
+        message = this.messageQueue.shift();
+      } else {
+        if (this.currentIndex >= this.messages.length) {
+          this.currentIndex = 0;
+        }
+        message = this.messages[this.currentIndex++];
       }
 
-      const message = this.messages[this.currentIndex++];
       this.displayMessage(message);
 
       this.timeoutId = setTimeout(() => {
@@ -70,6 +82,16 @@
           if (this.loopEnabled) this.cycleMessages();
         });
       }, this.showDuration);
+    }
+
+    triggerMessage(text) {
+      this.messageQueue.push(text);
+      if (this.loopEnabled) {
+        clearTimeout(this.timeoutId);
+        this.fadeOutCurrentMessage(() => {
+          this.cycleMessages();
+        });
+      }
     }
 
     displayMessage(text) {
@@ -103,6 +125,25 @@
       this.container.innerHTML = "";
       this.currentIndex = 0;
     }
+
+    setupInteractions() {
+      this.interactions.forEach(cfg => {
+        const elements = document.querySelectorAll(cfg.selector);
+        elements.forEach(el => {
+          el.addEventListener(cfg.event, () => {
+            this.triggerMessage(cfg.message);
+          });
+        });
+      });
+    }
+
+    setupTimeTriggers() {
+      this.timeTriggers.forEach(cfg => {
+        setTimeout(() => {
+          this.triggerMessage(cfg.message);
+        }, cfg.delay);
+      });
+    }
   }
 
   // Expose class in case you want to instantiate manually elsewhere
@@ -122,6 +163,33 @@
         "Check out my projects below!",
         "I hope you enjoy exploring!",
         "Feel free to reach out anytime."
+      ],
+      interactions: [
+        {
+          selector: '#download-resume-btn',
+          event: 'click',
+          message: 'Hope you like my resume!'
+        },
+        {
+          selector: '.page-up-arrow',
+          event: 'click',
+          message: 'Diving into details, cool!'
+        },
+        {
+          selector: '#scroll-arrow',
+          event: 'click',
+          message: "Let's explore!"
+        }
+      ],
+      timeTriggers: [
+        {
+          delay: 10000,
+          message: 'Still here? Check out the projects below.'
+        },
+        {
+          delay: 30000,
+          message: 'Need help finding something? Drop me a line!'
+        }
       ],
       showDuration: 4000,
       transitionGap: 3000 // 3.0s fade


### PR DESCRIPTION
## Summary
- enhance DynamicGuide with queued messages, interaction hooks, and time-based triggers
- initialize guide with button click reactions and timed suggestions

## Testing
- `node --check scripts/dynamic-guide.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e408b27648320829b0225d264f268