### PR TITLE
feat: update project links and order

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,12 +289,36 @@
         <h3>Projects</h3>
         <ul class="project-list">
           <li class="card">
+            <strong>OBJ Viewer + Raytracer</strong>
+            C++/OpenGL viewer + CPU raytracer with basic lighting.
+            <div class="project-actions">
+              <a href="https://github.com/QuinnAho/OpenGLOBJViewer" target="_blank" rel="noopener noreferrer">GitHub</a>
+            </div>
+          </li>
+          <li class="card">
+            <strong>Vision VR Enhancements</strong>
+            UX features and debug tools for Corvid’s in-house sim software.
+            <div class="project-actions">
+              <a href="https://youtu.be/MM4_4wsBuC8" target="_blank" rel="noopener noreferrer">Watch</a>
+            </div>
+          </li>
+          <li class="card">
+            <strong>AI Avatar Animation System</strong>
+            Real-time animation blending with Audio2Face + ElevenLabs.
+            <div class="project-actions">
+              <a href="https://youtu.be/xbMaAssRC9g" target="_blank" rel="noopener noreferrer">Watch</a>
+            </div>
+          </li>
+          <li class="card">
             <strong>KPI Recorder</strong>
             Unreal plugin to extract simulation data and compute KPIs for vehicle analysis.
           </li>
           <li class="card">
-            <strong>VR Educational Sim</strong>
+            <strong>VR Air Awareness Training Simulation</strong>
             Air-awareness trainer with real-time comeout control and hand tracking.
+            <div class="project-actions">
+              <a href="https://devpost.com/software/vr-air-awareness-training-simulator" target="_blank" rel="noopener noreferrer">Devpost</a>
+            </div>
           </li>
           <li class="card">
             <strong>Raytheon Cinematic</strong>
@@ -303,14 +327,9 @@
           <li class="card">
             <strong>ATD Positioning Tool</strong>
             VR IK tool to intuitively pose Hybrid III ATD with joint limits.
-          </li>
-          <li class="card">
-            <strong>UE5 Weather Viz</strong>
-            Weather visualization system for architectural workflows (C++/Blueprint).
-          </li>
-          <li class="card">
-            <strong>Vision VR Enhancements</strong>
-            UX features and debug tools for Corvid’s in-house sim software.
+            <div class="project-actions">
+              <a href="https://youtu.be/UsT4EdJYFr4" target="_blank" rel="noopener noreferrer">Watch</a>
+            </div>
           </li>
           <li class="card">
             <strong>Military Ground Vehicle Sim</strong>
@@ -318,7 +337,7 @@
           </li>
           <li class="card">
             <strong>Golem’s Curse</strong>
-            Full-length UE5 cinematic with original sound/post. 
+            Full-length UE5 cinematic with original sound/post.
             <div class="project-actions">
               <a href="https://www.youtube.com/watch?v=d8QPDpQtJI4" target="_blank" rel="noopener noreferrer">Watch</a>
             </div>
@@ -331,15 +350,11 @@
             </div>
           </li>
           <li class="card">
-            <strong>OBJ Viewer + Raytracer</strong>
-            C++/OpenGL viewer + CPU raytracer with basic lighting.
+            <strong>UE5 Weather Viz</strong>
+            Weather visualization system for architectural workflows (C++/Blueprint).
             <div class="project-actions">
-              <a href="https://github.com/QuinnAho/OpenGLOBJViewer" target="_blank" rel="noopener noreferrer">GitHub</a>
+              <a href="https://youtu.be/L1CMBg4MvKo" target="_blank" rel="noopener noreferrer">Watch</a>
             </div>
-          </li>
-          <li class="card">
-            <strong>AI Avatar Animation System</strong>
-            Real-time animation blending with Audio2Face + ElevenLabs.
           </li>
           <li class="card">
             <strong>Metahuman Punch Animation</strong>


### PR DESCRIPTION
## Summary
- move OBJ Viewer + Raytracer to top of projects
- add watch links for Vision VR Enhancements, AI Avatar Animation System, ATD Positioning Tool, and UE5 Weather Viz
- rename VR Educational Sim to VR Air Awareness Training Simulation with Devpost link

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f561d1c148320adf66b6136de98b1