### PR TITLE
Add responsive side navigation layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,19 +40,18 @@
   <body>
     <!-- Header -->
     <header class="main-header">
-      <nav class="left-nav">
-        <ul class="nav-links">
-          <li><a href="#projects">Projects</a></li>
-          <li><a href="#contact">Contact</a></li>
-          <li><a href="#experience">Experience</a></li>
-          <li><a href="#skills">Skills</a></li>
-          <li><a href="#education">Education</a></li>
-        </ul>
-      </nav>
-
       <div class="header-guide" id="header-guide"></div>
-      <div class="right-nav"></div>
     </header>
+
+    <nav class="side-nav">
+      <ul class="nav-links">
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#experience">Experience</a></li>
+        <li><a href="#education">Education</a></li>
+        <li><a href="#skills">Skills</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
 
     <!-- Hero -->
     <section class="hero">

--- a/index.html
+++ b/index.html
@@ -54,6 +54,14 @@
       </ul>
     </nav>
 
+    <div class="side-nav-arrow" aria-hidden="true">
+      <div class="arrow-icon">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 17.414l-6.707-6.707 1.414-1.414L12 14.586l5.293-5.293 1.414 1.414z"/>
+        </svg>
+      </div>
+    </div>
+
     <!-- Hero -->
     <section class="hero">
       <canvas></canvas>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
     </header>
 
     <nav class="side-nav">
+      <button class="side-nav-toggle" aria-label="Toggle navigation">&#x25C0;</button>
       <ul class="nav-links">
         <li><a href="#projects">Projects</a></li>
         <li><a href="#experience">Experience</a></li>
@@ -522,6 +523,7 @@
     <script src="scripts/intro-cube.js" defer></script>
     <script src="scripts/intro-pages.js" defer></script>
     <script src="scripts/sheets.js" defer></script>
+    <script src="scripts/side-nav.js" defer></script>
     <script src="scripts/header-nav.js" defer></script>
   </body>
 </html>

--- a/scripts/side-nav.js
+++ b/scripts/side-nav.js
@@ -1,13 +1,26 @@
 (() => {
   const body = document.body;
   const toggle = document.querySelector('.side-nav-toggle');
-  if (!toggle) return;
+  let pinned = false;
 
-  toggle.addEventListener('click', e => {
-    e.stopPropagation();
-    const open = body.classList.toggle('side-nav-open');
-    toggle.setAttribute('aria-expanded', open);
-    toggle.innerHTML = open ? '\u25C0' : '\u25B6';
+  if (toggle) {
+    toggle.addEventListener('click', e => {
+      e.stopPropagation();
+      pinned = !pinned;
+      body.classList.toggle('side-nav-open', pinned);
+      toggle.setAttribute('aria-expanded', pinned);
+      toggle.innerHTML = pinned ? '\u25C0' : '\u25B6';
+      if (!pinned) body.classList.remove('side-nav-hover');
+    });
+  }
+
+  document.addEventListener('mousemove', e => {
+    if (pinned) return;
+    if (e.clientX < window.innerWidth / 4) {
+      body.classList.add('side-nav-hover');
+    } else {
+      body.classList.remove('side-nav-hover');
+    }
   });
 })();
 

--- a/scripts/side-nav.js
+++ b/scripts/side-nav.js
@@ -1,0 +1,13 @@
+(() => {
+  const body = document.body;
+  const toggle = document.querySelector('.side-nav-toggle');
+  if (!toggle) return;
+
+  toggle.addEventListener('click', e => {
+    e.stopPropagation();
+    const open = body.classList.toggle('side-nav-open');
+    toggle.setAttribute('aria-expanded', open);
+    toggle.innerHTML = open ? '\u25C0' : '\u25B6';
+  });
+})();
+

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@ html, body {
 body {
   font-family: 'Inter', sans-serif;
   color: #fff;
-  margin-left: var(--side-nav-w);
+  margin-left: 0;
 }
 
 /* Visual constants */
@@ -31,6 +31,9 @@ body {
 
   /* Flat interior */
   --surface-gray: #e6e6e6;
+
+  /* Width of left nav when shown */
+  --nav-peek: 12px;
 }
 
 /* ===============================
@@ -39,8 +42,8 @@ body {
 .main-header {
   position: fixed;
   top: 0;
-  left: var(--side-nav-w);
-  width: calc(100% - var(--side-nav-w));
+  left: 0;
+  width: 100%;
   height: var(--header-h);
   display: flex;
   align-items: center;
@@ -57,8 +60,8 @@ body {
   content: '';
   position: absolute;
   top: 0;
-  left: calc(-1 * var(--side-nav-w));
-  width: calc(100% + var(--side-nav-w));
+  left: 0;
+  width: 100%;
   height: 100%;
   border-bottom: 1px solid rgba(255,255,255,0.05);
   pointer-events: none;
@@ -74,6 +77,28 @@ body {
   display: flex;
   justify-content: center;
   z-index: 999;
+  transform: translateX(calc(-100% + var(--nav-peek)));
+  transition: transform 0.3s ease;
+}
+
+.side-nav:hover,
+body.side-nav-open .side-nav {
+  transform: translateX(0);
+}
+
+.side-nav-toggle {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  color: rgba(255,255,255,0.7);
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+body.side-nav-open .side-nav-toggle {
+  transform: rotate(180deg);
 }
 
 .side-nav .nav-links {
@@ -130,12 +155,14 @@ body {
     width: 100%;
     height: auto;
     padding: 0.8rem 1rem;
+    transform: none;
   }
   .side-nav .nav-links {
     flex-direction: row;
     gap: 1rem;
     justify-content: center;
   }
+  .side-nav-toggle { display: none; }
   .nav-links a {
     font-size: 0.75rem;
   }

--- a/styles.css
+++ b/styles.css
@@ -82,7 +82,8 @@ body {
 }
 
 .side-nav:hover,
-body.side-nav-open .side-nav {
+body.side-nav-open .side-nav,
+body.side-nav-hover .side-nav {
   transform: translateX(0);
 }
 
@@ -133,6 +134,42 @@ body.side-nav-open .side-nav-toggle {
 
 .nav-links a:hover::after { width: 100%; }
 
+/* Bouncing arrow hint for side navigation */
+.side-nav-arrow {
+  position: fixed;
+  top: 50%;
+  left: calc(var(--nav-peek) + 10px);
+  animation: bounce-x 2s infinite;
+  background: rgba(0,0,0,0.2);
+  backdrop-filter: blur(5px);
+  padding: 15px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 998;
+  transition: opacity 0.3s ease;
+}
+
+.side-nav-arrow .arrow-icon { transform: rotate(-90deg); }
+
+.side-nav-arrow svg {
+  width: 30px;
+  height: 30px;
+  fill: rgba(255,255,255,0.8);
+}
+
+@keyframes bounce-x {
+  0%, 20%, 50%, 80%, 100% { transform: translateY(-50%) translateX(0); }
+  40% { transform: translateY(-50%) translateX(10px); }
+  60% { transform: translateY(-50%) translateX(5px); }
+}
+
+body.side-nav-hover .side-nav-arrow,
+body.side-nav-open .side-nav-arrow {
+  display: none;
+}
+
 /* Dynamic guide centered in header */
 .header-guide {
   position: absolute;
@@ -166,6 +203,7 @@ body.side-nav-open .side-nav-toggle {
   .nav-links a {
     font-size: 0.75rem;
   }
+  .side-nav-arrow { display: none; }
 }
 
 .animated-message { opacity: 0; transition: opacity 0.5s ease; }

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,7 @@ html, body {
 body {
   font-family: 'Inter', sans-serif;
   color: #fff;
+  margin-left: var(--side-nav-w);
 }
 
 /* Visual constants */
@@ -37,25 +38,44 @@ body {
    =============================== */
 .main-header {
   position: fixed;
+  top: 0;
+  left: var(--side-nav-w);
+  width: calc(100% - var(--side-nav-w));
+  height: var(--header-h);
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 1.2rem 2rem;
+  justify-content: center;
+  padding: 0 2rem;
   background-color: rgba(0,0,0,0.7);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   z-index: 1000;
-  top: 0; left: 0; width: 100%;
   border-bottom: 1px solid rgba(255,255,255,0.05);
 }
 
-.main-header .nav-links {
+.side-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--side-nav-w);
+  height: 100vh;
+  padding-top: var(--header-h);
+  background-color: rgba(0,0,0,0.7);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   display: flex;
-  list-style: none;
-  gap: 3rem;
+  justify-content: center;
+  z-index: 999;
 }
 
-.main-header nav a {
+.side-nav .nav-links {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  gap: 2rem;
+}
+
+.nav-links a {
   color: rgba(255,255,255,0.9);
   text-decoration: none;
   font-size: 0.85rem;
@@ -67,9 +87,9 @@ body {
   transition: all 0.3s ease;
 }
 
-.main-header nav a:hover { color: #fff; }
+.nav-links a:hover { color: #fff; }
 
-.main-header nav a::after {
+.nav-links a::after {
   content: '';
   position: absolute;
   bottom: 0; left: 0;
@@ -78,7 +98,7 @@ body {
   transition: width 0.3s ease;
 }
 
-.main-header nav a:hover::after { width: 100%; }
+.nav-links a:hover::after { width: 100%; }
 
 /* Dynamic guide centered in header */
 .header-guide {
@@ -91,14 +111,24 @@ body {
 
 /* Responsive tweaks for small screens */
 @media (max-width: 600px) {
+  :root { --side-nav-w: 0; }
   .main-header {
+    left: 0;
+    width: 100%;
     padding: 0.8rem 1rem;
   }
-  .main-header .nav-links {
-    gap: 1rem;
-    overflow-x: auto;
+  .side-nav {
+    top: var(--header-h);
+    width: 100%;
+    height: auto;
+    padding: 0.8rem 1rem;
   }
-  .main-header nav a {
+  .side-nav .nav-links {
+    flex-direction: row;
+    gap: 1rem;
+    justify-content: center;
+  }
+  .nav-links a {
     font-size: 0.75rem;
   }
 }
@@ -695,7 +725,7 @@ html, body{
   scroll-behavior: smooth;         /* base smoothness */
 }
 
-:root { --header-h: 70px; } /* adjust if your header is taller/shorter */
+:root { --header-h: 70px; --side-nav-w: 180px; } /* adjust if your header is taller/shorter */
 
 html { 
   scroll-padding-top: var(--header-h); /* anchors/snap land below header */

--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,18 @@ body {
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   z-index: 1000;
+  border-bottom: none;
+}
+
+.main-header::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: calc(-1 * var(--side-nav-w));
+  width: calc(100% + var(--side-nav-w));
+  height: 100%;
   border-bottom: 1px solid rgba(255,255,255,0.05);
+  pointer-events: none;
 }
 
 .side-nav {
@@ -60,9 +71,6 @@ body {
   width: var(--side-nav-w);
   height: 100vh;
   padding-top: var(--header-h);
-  background-color: rgba(0,0,0,0.7);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
   display: flex;
   justify-content: center;
   z-index: 999;


### PR DESCRIPTION
## Summary
- Move navigation links into a fixed left sidebar while keeping the dynamic guide at the top
- Style side navigation with CSS variables and responsive mobile layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5dfc2c188320a165891c836074a7