### PR TITLE
Trigger side nav on arrow hover and center link list

### DIFF
--- a/scripts/side-nav.js
+++ b/scripts/side-nav.js
@@ -1,6 +1,8 @@
 (() => {
   const body = document.body;
   const toggle = document.querySelector('.side-nav-toggle');
+  const arrow = document.querySelector('.side-nav-arrow');
+  const sideNav = document.querySelector('.side-nav');
   let pinned = false;
 
   if (toggle) {
@@ -14,13 +16,23 @@
     });
   }
 
-  document.addEventListener('mousemove', e => {
-    if (pinned) return;
-    if (e.clientX < window.innerWidth / 4) {
-      body.classList.add('side-nav-hover');
-    } else {
-      body.classList.remove('side-nav-hover');
-    }
-  });
+  if (arrow && sideNav) {
+    arrow.addEventListener('mouseenter', () => {
+      if (!pinned) body.classList.add('side-nav-hover');
+    });
+
+    sideNav.addEventListener('mouseleave', () => {
+      if (!pinned) body.classList.remove('side-nav-hover');
+    });
+
+    document.addEventListener('mousemove', e => {
+      if (pinned) return;
+      if (sideNav.contains(e.target)) {
+        body.classList.add('side-nav-hover');
+      } else if (!arrow.contains(e.target)) {
+        body.classList.remove('side-nav-hover');
+      }
+    });
+  }
 })();
 

--- a/styles.css
+++ b/styles.css
@@ -74,8 +74,11 @@ body {
   width: var(--side-nav-w);
   height: 100vh;
   padding-top: var(--header-h);
+  padding-bottom: var(--header-h);
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
   z-index: 999;
   transform: translateX(calc(-100% + var(--nav-peek)));
   transition: transform 0.3s ease;


### PR DESCRIPTION
## Summary
- Open side navigation when hovering over bouncing arrow instead of screen edge
- Center side-nav link list vertically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f683291848320a428d92f4e9aad4d