### PR TITLE
Improve scroll arrow and modernize cube icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,6 +524,14 @@
         clearTimeout(tId);
         tId = setTimeout(snap, SNAP_DELAY);
       }, { passive:true });
+
+      const arrow = document.getElementById('scroll-arrow');
+      if (arrow && SECTIONS[1]) {
+        arrow.addEventListener('click', e => {
+          e.preventDefault();
+          animateScroll(window.scrollY, SECTIONS[1].offsetTop, SNAP_MS);
+        });
+      }
     })();
     </script>
     <script src="scripts/fluid-sim.js"></script>

--- a/media/icons/contact.svg
+++ b/media/icons/contact.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="3" y="5" width="18" height="14" rx="2" ry="2" fill="none" stroke="#fff" stroke-width="2"/>
+  <path d="M3 7l9 6 9-6" fill="none" stroke="#fff" stroke-width="2"/>
+</svg>

--- a/media/icons/education.svg
+++ b/media/icons/education.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 9l9-4 9 4-9 4-9-4zm9 4v6m6-3v-3l-6-2-6 2v3" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/icons/experience.svg
+++ b/media/icons/experience.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 7h16v13H4z" fill="none" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M9 7V5h6v2" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/icons/home.svg
+++ b/media/icons/home.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 10l9-7 9 7v10a2 2 0 0 1-2 2h-4v-6h-6v6H5a2 2 0 0 1-2-2z" fill="none" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/media/icons/projects.svg
+++ b/media/icons/projects.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 7h6l2 2h10v9H3z" fill="none" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/media/icons/skills.svg
+++ b/media/icons/skills.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="3" fill="none" stroke="#fff" stroke-width="2"/>
+  <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- Fix scroll arrow so tapping it smoothly moves to the next section
- Replace emoji faces on intro cube with SVG icon textures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2111077cc8320947ef665e2a28b8d